### PR TITLE
Implement distributed client-server checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,23 @@ invalid url: An invalid URL
 does not resolve: https://wat/foo.js
 does not resolve: https://notarealsubdomain.example.com/
 ```
+
+## Distributed usage
+
+The project also provides a simple client/server mode. Start one or more
+servers:
+
+```
+▶ go run ./cmd/server -addr :8080
+```
+
+Then run the client providing the list of servers, total threads and the
+URLs to check:
+
+```
+▶ cat urls | go run ./cmd/client -servers "server1:8080,server2:8080" -threads 50
+```
+
+The client will detect which servers are reachable, split the URLs between
+them and divide the total number of threads proportionally.
+The results from each server are printed on the client.

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -1,0 +1,105 @@
+package checker
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+)
+
+type Result struct {
+	URL    string `json:"url"`
+	Status string `json:"status,omitempty"`
+	Error  string `json:"error,omitempty"`
+}
+
+func CheckURLs(urls []string, concurrency int) []Result {
+	if concurrency < 1 {
+		concurrency = 1
+	}
+	jobs := make(chan string)
+	res := make(chan Result)
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+	for i := 0; i < concurrency; i++ {
+		go func() {
+			defer wg.Done()
+			for u := range jobs {
+				res <- checkURL(u)
+			}
+		}()
+	}
+
+	go func() {
+		for _, u := range urls {
+			jobs <- u
+		}
+		close(jobs)
+		wg.Wait()
+		close(res)
+	}()
+
+	var results []Result
+	for r := range res {
+		results = append(results, r)
+	}
+	return results
+}
+
+func checkURL(raw string) Result {
+	u, err := url.ParseRequestURI(raw)
+	if err != nil {
+		return Result{URL: raw, Error: "invalid url"}
+	}
+
+	if !resolves(u) {
+		return Result{URL: u.String(), Error: "does not resolve"}
+	}
+
+	resp, err := fetchURL(u)
+	if err != nil {
+		return Result{URL: u.String(), Error: fmt.Sprintf("failed to fetch: %v", err)}
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return Result{URL: u.String(), Status: resp.Status, Error: "non-200 response"}
+	}
+
+	return Result{URL: u.String(), Status: resp.Status}
+}
+
+func resolves(u *url.URL) bool {
+	addrs, _ := net.LookupHost(u.Hostname())
+	return len(addrs) != 0
+}
+
+func fetchURL(u *url.URL) (*http.Response, error) {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := http.Client{
+		Transport: tr,
+		Timeout:   5 * time.Second,
+	}
+
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Close = true
+	req.Header.Set("User-Agent", "burl/0.1")
+
+	resp, err := client.Do(req)
+	if resp != nil {
+		resp.Body.Close()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, err
+}

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+)
+
+func readURLs(r io.Reader) ([]string, error) {
+	var urls []string
+	sc := bufio.NewScanner(r)
+	for sc.Scan() {
+		urls = append(urls, sc.Text())
+	}
+	return urls, sc.Err()
+}
+
+type checkRequest struct {
+	URLs    []string `json:"urls"`
+	Threads int      `json:"threads"`
+}
+
+type checkResponse struct {
+	Results []struct {
+		URL    string `json:"url"`
+		Status string `json:"status,omitempty"`
+		Error  string `json:"error,omitempty"`
+	} `json:"results"`
+}
+
+func main() {
+	var file string
+	var threadTotal int
+	var serverList string
+	flag.StringVar(&file, "file", "", "file with URLs (default stdin)")
+	flag.IntVar(&threadTotal, "threads", 10, "total threads across servers")
+	flag.StringVar(&serverList, "servers", "", "comma separated list of server addresses (host:port)")
+	flag.Parse()
+
+	var input io.Reader = os.Stdin
+	if file != "" {
+		f, err := os.Open(file)
+		if err != nil {
+			log.Fatalf("failed to open file: %v", err)
+		}
+		defer f.Close()
+		input = f
+	}
+
+	urls, err := readURLs(input)
+	if err != nil {
+		log.Fatalf("failed to read urls: %v", err)
+	}
+	if len(urls) == 0 {
+		log.Fatal("no urls provided")
+	}
+
+	servers := strings.Split(serverList, ",")
+	var active []string
+	for _, srv := range servers {
+		srv = strings.TrimSpace(srv)
+		if srv == "" {
+			continue
+		}
+		resp, err := http.Get("http://" + srv + "/health")
+		if err == nil && resp.StatusCode == http.StatusOK {
+			active = append(active, srv)
+		} else {
+			log.Printf("server %s unreachable", srv)
+		}
+	}
+	if len(active) == 0 {
+		log.Fatal("no active servers")
+	}
+
+	m := len(active)
+	per := len(urls) / m
+	extra := len(urls) % m
+	threadsPer := threadTotal / m
+	if threadsPer == 0 {
+		threadsPer = 1
+	}
+
+	offset := 0
+	for i, srv := range active {
+		count := per
+		if i < extra {
+			count++
+		}
+		batch := urls[offset : offset+count]
+		offset += count
+		reqBody, _ := json.Marshal(checkRequest{URLs: batch, Threads: threadsPer})
+		resp, err := http.Post("http://"+srv+"/check", "application/json", bytes.NewReader(reqBody))
+		if err != nil {
+			log.Printf("server %s failed: %v", srv, err)
+			continue
+		}
+		var cr checkResponse
+		if err := json.NewDecoder(resp.Body).Decode(&cr); err != nil {
+			log.Printf("bad response from %s: %v", srv, err)
+			resp.Body.Close()
+			continue
+		}
+		resp.Body.Close()
+		for _, r := range cr.Results {
+			if r.Error != "" {
+				fmt.Printf("%s: %s\n", r.URL, r.Error)
+			} else if r.Status != "" && r.Status != "200 OK" {
+				fmt.Printf("%s: %s\n", r.URL, r.Status)
+			}
+		}
+	}
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"log"
+	"net/http"
+
+	"github.com/tomnomnom/burl/checker"
+)
+
+type checkRequest struct {
+	URLs    []string `json:"urls"`
+	Threads int      `json:"threads"`
+}
+
+type checkResponse struct {
+	Results []checker.Result `json:"results"`
+}
+
+func handleCheck(w http.ResponseWriter, r *http.Request) {
+	var req checkRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	results := checker.CheckURLs(req.URLs, req.Threads)
+	json.NewEncoder(w).Encode(checkResponse{Results: results})
+}
+
+func handleHealth(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("OK"))
+}
+
+func main() {
+	addr := flag.String("addr", ":8080", "listen address")
+	flag.Parse()
+
+	http.HandleFunc("/check", handleCheck)
+	http.HandleFunc("/health", handleHealth)
+
+	log.Printf("server listening on %s", *addr)
+	log.Fatal(http.ListenAndServe(*addr, nil))
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/tomnomnom/burl
+
+go 1.23.8


### PR DESCRIPTION
## Summary
- create `checker` package with URL checking logic
- add server exposing `/check` and `/health` endpoints
- add client that splits workload across available servers
- describe distributed usage in README
- initialize Go module

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_685ff3188e408324a12c39c95007b3e5